### PR TITLE
Support float value in EstimateValue

### DIFF
--- a/src/Models/EstimateValue.cs
+++ b/src/Models/EstimateValue.cs
@@ -5,6 +5,6 @@ namespace ZenHub.Models
     public class EstimateValue
     {
         [JsonPropertyName("value")]
-        public int Value { get; set; }
+        public float Value { get; set; }
     }
 }


### PR DESCRIPTION
Nowadays, Zenhub supports float value in the estimation of issue. 
The API https://github.com/ZenHubIO/API#get-a-zenhub-board-for-a-repository will fail when the estimation in the issue is in float type.